### PR TITLE
Percentile implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ keywords = ["statistics", "statistical", "analysis", "math", "algorithm"]
 [dependencies]
 rand = "0.6"
 num = "0.2"
+order-stat = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "statistical"
 description = "A simple statistics library"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Jeff Belgum <jeffbelgum@gmail.com>"]
 
 repository = "https://github.com/JeffBelgum/statistical"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "statistical"
 description = "A simple statistics library"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Jeff Belgum <jeffbelgum@gmail.com>"]
 
 repository = "https://github.com/JeffBelgum/statistical"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,5 +52,6 @@ pub use stats_::{
     population_variance,
     standard_deviation,
     population_standard_deviation,
-    standard_scores
+    standard_scores,
+    percentile,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 
 extern crate rand;
 extern crate num;
+extern crate order_stat;
 
 mod univariate_;
 mod stats_;

--- a/src/stats_.rs
+++ b/src/stats_.rs
@@ -137,11 +137,18 @@ pub fn standard_scores<T>(v: &[T]) -> Vec<T>
     return scores;
 }
 
-pub fn percentile<T>(v: &[T], ratio: f32) -> f32
+pub fn percentile<T>(v: &[T], ratio: f32) -> T
     where T: Float
 {
     assert!(ratio > 0.0 && ratio < 1.0);
-    0.0
+    let mut sorted = Vec::from(v);
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let index = ratio * sorted.len() as f32;
+    if index.fract() == 0.0 {
+        (sorted[index as usize] + sorted[index as usize - 1]) / NumCast::from(2.0).unwrap()
+    } else {
+        sorted[index as usize]
+    }
 }
 
 #[inline(always)]
@@ -275,6 +282,11 @@ mod tests {
         assert_eq!(percentile(arr, 0.25), 4.0);
         assert_eq!(percentile(arr, 0.50), 5.0);
         assert_eq!(percentile(arr, 0.75), 7.0);
+        let arr = &[1.0, 3.0, 3.0, 4.0, 5.0, 6.0, 6.0, 7.0, 8.0, 8.0,];
+        assert_eq!(percentile(arr, 0.25), 3.0);
+        assert_eq!(percentile(arr, 0.50), 5.5);
+        assert_eq!(percentile(arr, 0.75), 7.0);
+        assert_eq!(percentile(&[1.0, 2.0, 3.0,], 2.0/3.0), 5.0/2.0);
     }
 
     #[test]

--- a/src/stats_.rs
+++ b/src/stats_.rs
@@ -17,7 +17,6 @@
 
 extern crate rand;
 extern crate num;
-extern crate order_stat;
 
 use num::{Float,
           Num,

--- a/src/stats_.rs
+++ b/src/stats_.rs
@@ -137,6 +137,13 @@ pub fn standard_scores<T>(v: &[T]) -> Vec<T>
     return scores;
 }
 
+pub fn percentile<T>(v: &[T], ratio: f32) -> f32
+    where T: Float
+{
+    assert!(ratio > 0.0 && ratio < 1.0);
+    0.0
+}
+
 #[inline(always)]
 fn select_pivot<T>(v: &mut [T])
     where T: Copy
@@ -260,6 +267,14 @@ mod tests {
         let v = vec![0.0, 0.25, 0.25, 1.25, 1.5, 1.75, 2.75, 3.25];
         let expected = vec![-1.150407536484354, -0.941242529850835, -0.941242529850835, -0.10458250331675945, 0.10458250331675945, 0.31374750995027834, 1.150407536484354, 1.5687375497513918];
         assert!(expected == standard_scores(&v));
+    }
+
+    #[test]
+    fn test_percentile() {
+        let arr = &[5.0, 7.0, 4.0, 4.0, 6.0, 2.0, 8.0,];
+        assert_eq!(percentile(arr, 0.25), 4.0);
+        assert_eq!(percentile(arr, 0.50), 5.0);
+        assert_eq!(percentile(arr, 0.75), 7.0);
     }
 
     #[test]

--- a/src/stats_.rs
+++ b/src/stats_.rs
@@ -17,12 +17,14 @@
 
 extern crate rand;
 extern crate num;
+extern crate order_stat;
 
 use num::{Float,
           Num,
           NumCast,
           One,
           Zero};
+use order_stat::kth_by;
 
 
 pub enum Degree {
@@ -141,13 +143,13 @@ pub fn percentile<T>(v: &[T], ratio: f32) -> T
     where T: Float
 {
     assert!(ratio > 0.0 && ratio < 1.0);
+    let index = ratio * v.len() as f32;
     let mut sorted = Vec::from(v);
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let index = ratio * sorted.len() as f32;
+    let result = *kth_by(&mut sorted, index as usize, |x, y| x.partial_cmp(y).unwrap());
     if index.fract() == 0.0 {
-        (sorted[index as usize] + sorted[index as usize - 1]) / NumCast::from(2.0).unwrap()
+        (result + sorted[index as usize - 1]) / NumCast::from(2.0).unwrap()
     } else {
-        sorted[index as usize]
+        result
     }
 }
 


### PR DESCRIPTION
Added percentile finding function, which makes use of `order-stat` crate's `kth_by` function.
This makes time complexity of percentile function to be `O(N)`.